### PR TITLE
Adding enable anaconda dropzone option

### DIFF
--- a/lib/anaconda/form_builder_helpers.rb
+++ b/lib/anaconda/form_builder_helpers.rb
@@ -7,10 +7,16 @@ module Anaconda
       options = {}
       
       # It would be safer if I could figure out how to make this sequential:
-      element_id = "anaconda_file_#{anaconda_field_name}_#{rand(999999999)}" 
-      
-      output += "<div class='not_anaconda_dropzone'>"
-      
+      element_id = "anaconda_file_#{anaconda_field_name}_#{rand(999999999)}"
+
+      if form_options[:enable_dropzone]
+        # Note, there is a known bug in dropzones that cause an issue in chrome to make file browser appear twice.
+        # Only use dropzones in lieu of "select file" button
+        output += "<div class='anaconda_dropzone'>"
+      else
+        output += "<div class='not_anaconda_dropzone'>"
+      end
+
       if form_options[:dropzone_text].present?
         output += "<div class='anaconda_dropzone_text'>#{form_options[:dropzone_text]}</div>"
       end
@@ -81,7 +87,6 @@ module Anaconda
       output += <<-END
 <div id="#{upload_details_container_id}" class="anaconda_upload_details_container"></div>
 <script>
-  document.addEventListener("DOMContentLoaded", function() {
     (function() {
       new AnacondaUploadField({
         element_id: "##{options[:element_id]}",
@@ -94,7 +99,6 @@ module Anaconda
         attribute: "#{options[:as]}"
       });
     }).call(this);
-    });
 </script>
 
       END

--- a/lib/anaconda/form_builder_helpers.rb
+++ b/lib/anaconda/form_builder_helpers.rb
@@ -87,6 +87,7 @@ module Anaconda
       output += <<-END
 <div id="#{upload_details_container_id}" class="anaconda_upload_details_container"></div>
 <script>
+    document.addEventListener("DOMContentLoaded", function() {
     (function() {
       new AnacondaUploadField({
         element_id: "##{options[:element_id]}",
@@ -99,6 +100,7 @@ module Anaconda
         attribute: "#{options[:as]}"
       });
     }).call(this);
+    })
 </script>
 
       END

--- a/lib/anaconda/form_builder_helpers.rb
+++ b/lib/anaconda/form_builder_helpers.rb
@@ -100,7 +100,7 @@ module Anaconda
         attribute: "#{options[:as]}"
       });
     }).call(this);
-    })
+  })
 </script>
 
       END

--- a/lib/anaconda/form_builder_helpers.rb
+++ b/lib/anaconda/form_builder_helpers.rb
@@ -87,7 +87,7 @@ module Anaconda
       output += <<-END
 <div id="#{upload_details_container_id}" class="anaconda_upload_details_container"></div>
 <script>
-    document.addEventListener("DOMContentLoaded", function() {
+  document.addEventListener("DOMContentLoaded", function() {
     (function() {
       new AnacondaUploadField({
         element_id: "##{options[:element_id]}",

--- a/lib/anaconda/version.rb
+++ b/lib/anaconda/version.rb
@@ -1,5 +1,5 @@
 module Anaconda
   module Rails
-    VERSION = "5.0.9"
+    VERSION = "5.0.10"
   end
 end


### PR DESCRIPTION
This is a quick fix to the current issues with anaconda dropzones. Allows addition of dropzones back into the form. Note, dropzones should not be used in conjunction with a file select button, as there is a known issue with chrome where the file browser will pop up twice.